### PR TITLE
Enhance README and command functionality to support activity type filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,67 @@
 
 ## Overview
 
-This is a GitHub CLI extension that helps you identify dormant users in your organization. It checks for commit, issue, and pull request activity and generates a CSV report of dormant users.
+`gh-dormant-users` is a GitHub CLI extension that helps you identify dormant users in your organization. It checks for various types of activity such as commits, issues, issue comments, and pull request comments, and generates a CSV report of dormant users. This tool is useful for maintaining active participation in your organization's repositories.
 
 ## Installation
 
+To install the extension, use the following command:
+
 ```bash
 gh extension install ssulei7/gh-dormant-users
-``` 
+```
 
-## Usage 
+## Usage
+
+The primary command for this extension is `report`, which generates a report of dormant users based on specified criteria.
 
 ```zsh
-
 gh dormant-users report [flags]
-
-Flags:
-      --date string       The date from which to start looking for activity. Max 3 months in the past. (required)
-  -e, --email             Check if user has an email 
-  -h, --help              help for report
-    --org-name string   The name of the organization to report upon (required)
 ```
 
-## Example
+### Flags
+
+- `--date string`: The date from which to start looking for activity. Max 3 months in the past. (required)
+- `-e, --email`: Check if user has an email.
+- `--org-name string`: The name of the organization to report upon. (required)
+- `--activity-types strings`: Comma-separated list of activity types to check (commits, issues, issue-comments, pr-comments). Default is all types.
+
+### Example
+
+To generate a report for the organization `foobar` starting from March 1, 2024, and checking all activity types:
 
 ```zsh
-    gh dormant-users report --date "Mar 1 2024" --org-name foobar
+gh dormant-users report --date "Mar 1 2024" --org-name foobar
 ```
+
+To generate a report for the organization `foobar` starting from March 1, 2024, and only checking commit and issue activity:
+
+```zsh
+gh dormant-users report --date "Mar 1 2024" --org-name foobar --activity-types commits,issues
+```
+
+## Output
+
+The tool generates a CSV report of dormant users and displays a bar chart of active vs. inactive users. The CSV file is saved in the current directory with the name `<org-name>-dormant-users.csv`.
+
+### CSV Schema
+
+The generated CSV file has the following schema:
+
+| Username | Email          | Active |
+|----------|----------------|--------|
+| user1    | user1@domain.com | true   |
+| user2    | user2@domain.com | false  |
+| ...      | ...            | ...    |
+
+- **Username**: The GitHub username of the user.
+- **Email**: The email address of the user (if available).
+- **Active**: A boolean value indicating whether the user is active or not.
+
 ## Contributing
 
-This is a work in progress, and I am looking for contributors. Please feel free to open an issue or PR if you have any feedback or would like to contribute.
+This is a work in progress, and contributions are welcome. Please feel free to open an issue or PR if you have any feedback or would like to contribute.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -38,6 +38,8 @@ func generateDormantUserReport(cmd *cobra.Command, args []string) {
 
 	repositories := repository.GetOrgRepositories(orgName, client)
 
+	activityTypes, _ := cmd.Flags().GetStringSlice("activity-types")
+
 	// Now, check for activity in the organization's repositories
 	box := pterm.DefaultBox.WithTitle("Organization Info").
 		WithLeftPadding(1).
@@ -46,7 +48,7 @@ func generateDormantUserReport(cmd *cobra.Command, args []string) {
 		WithTopPadding(1)
 	box.Printfln("Number of users: %v\nNumber of repositories: %v", len(users), len(repositories))
 	pterm.Info.Println("Checking for activity...")
-	activity.CheckActivity(users, orgName, repositories, isoDate, client)
+	activity.CheckActivity(users, orgName, repositories, isoDate, client, activityTypes)
 	activity.GenerateBarChartOfActiveUsers()
 	activity.GenerateUserReportCSV(users, orgName+"-dormant-users.csv")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ func init() {
 	reportCmd.Flags().String("org-name", "", "The name of the organization to report upon")
 	reportCmd.Flags().BoolP("email", "e", false, "Check if user has an email")
 	reportCmd.Flags().String("date", "", "The date from which to start looking for activity. Max 3 months in the past.")
+	reportCmd.Flags().StringSlice("activity-types", []string{"commits", "issues", "issue-comments", "pr-comments"}, "Comma-separated list of activity types to check (commits, issues, issue-comments, pr-comments)")
 	if err := reportCmd.MarkFlagRequired("org-name"); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -23,14 +23,22 @@ func init() {
 	activeUsers = make(map[string]bool)
 }
 
-func CheckActivity(users users.Users, organization string, repositories repository.Repositories, date string, client api.RESTClient) {
+func CheckActivity(users users.Users, organization string, repositories repository.Repositories, date string, client api.RESTClient, activityTypes []string) {
 	for _, user := range users {
 		activeUsers[user.Login] = false
 	}
-	commitActivity(users, organization, repositories, date, client)
-	issueActivity(users, organization, repositories, date, client)
-	issueCommentActivity(users, organization, repositories, date, client)
-	pullRequestCommentActivity(users, organization, repositories, date, client)
+	for _, activityType := range activityTypes {
+		switch activityType {
+		case "commits":
+			commitActivity(users, organization, repositories, date, client)
+		case "issues":
+			issueActivity(users, organization, repositories, date, client)
+		case "issue-comments":
+			issueCommentActivity(users, organization, repositories, date, client)
+		case "pr-comments":
+			pullRequestCommentActivity(users, organization, repositories, date, client)
+		}
+	}
 }
 
 func commitActivity(usersList users.Users, organization string, repositories repository.Repositories, date string, client api.RESTClient) {


### PR DESCRIPTION
This pull request enhances the functionality of the `gh-dormant-users` GitHub CLI extension by introducing new features and improving documentation. The most significant changes include the addition of a new flag for specifying activity types,  and modifications to the activity checking logic.