### PR TITLE
Fix - Move limiter logic for retrieving issue activity

### DIFF
--- a/internal/issues/issues.go
+++ b/internal/issues/issues.go
@@ -38,8 +38,8 @@ func GetIssuesSinceDate(organization string, repo string, date string, client ap
 	url := fmt.Sprintf("repos/%s/%s/issues?per_page=100&since=%s", organization, repo, date)
 	for {
 		limiter.AcquireConcurrentLimiter()
-		defer limiter.ReleaseConcurrentLimiter()
 		response, err := client.Request("GET", url, nil)
+		limiter.ReleaseConcurrentLimiter()
 		if err != nil {
 			if strings.Contains(err.Error(), "Git Repository is empty.") {
 				break
@@ -80,8 +80,8 @@ func GetIssueCommentsSinceDate(organization string, repo string, date string, cl
 	url := fmt.Sprintf("repos/%s/%s/issues/comments?per_page=100&since=%s", organization, repo, date)
 	for {
 		limiter.AcquireConcurrentLimiter()
-		defer limiter.ReleaseConcurrentLimiter()
 		response, err := client.Request("GET", url, nil)
+		limiter.ReleaseConcurrentLimiter()
 		if err != nil {
 			if strings.Contains(err.Error(), "Git Repository is empty.") {
 				break


### PR DESCRIPTION
This pull request includes changes to the `internal/issues/issues.go` file to improve the resource management of concurrent limiters in the `GetIssuesSinceDate` and `GetIssueCommentsSinceDate` functions. The most important changes include modifying the release of the concurrent limiter to ensure it happens immediately after the request is made, rather than deferring it.