### PR TITLE
feat: add outside collaborator support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	reportCmd.Flags().String("org-name", "", "The name of the organization to report upon")
 	reportCmd.Flags().BoolP("email", "e", false, "Check if user has an email")
+	reportCmd.Flags().BoolP("outside-collaborators", "", false, "Also include outside collaborators in the report")
 	reportCmd.Flags().String("date", "", "The date from which to start looking for activity. Max 3 months in the past.")
 	reportCmd.Flags().StringSlice("activity-types", []string{"commits", "issues", "issue-comments", "pr-comments"}, "Comma-separated list of activity types to check (commits, issues, issue-comments, pr-comments)")
 	if err := reportCmd.MarkFlagRequired("org-name"); err != nil {

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -22,13 +22,22 @@ type User struct {
 type Users []User
 
 func GetOrganizationUsers(organization string, email bool, client api.RESTClient) Users {
-	pterm.Info.Printf("Starting to fetch users for organization: %s\n", organization)
+	pterm.Info.Printf("Starting to fetch members for organization: %s\n", organization)
+    return GetUsers(organization, "orgs/%s/members?per_page=100", email, client)
+}
+
+func GetOrganizationOutsideCollaborators(organization string, email bool, client api.RESTClient) Users {
+	pterm.Info.Printf("Starting to fetch outside collaborators for organization: %s\n", organization)
+    return GetUsers(organization, "orgs/%s/outside_collaborators?per_page=100", email, client)
+}
+
+func GetUsers(organization string, endpoint string, email bool, client api.RESTClient) Users {
 	var allUsers Users
 
 	// Start the spinner
 	spinner, _ := pterm.DefaultSpinner.Start("Fetching users...")
 
-	url := fmt.Sprintf("orgs/%s/members?per_page=100", organization)
+	url := fmt.Sprintf(endpoint, organization)
 	for {
 		response, err := client.Request("GET", url, nil)
 		if err != nil {


### PR DESCRIPTION
This repo is great. I think a common use case is also checking for dormant outside collaborators since they still consume Github licenses. Here is a possible implementation.
```
$ gh dormant-users report --date "Apr 2 2025" --org-name REDACT --outside-collaborators
 INFO  Starting to fetch members for organization: REDACT
 SUCCESS  Fetched users successfully
 INFO  Starting to fetch outside collaborators for organization: REDACT
 SUCCESS  Fetched users successfully
 SUCCESS  Fetched repositories successfully
 INFO  Fetched REDACT repositories
```