### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ssulei7/gh-dormant-users/security/code-scanning/1](https://github.com/ssulei7/gh-dormant-users/security/code-scanning/1)

In general, fix this by explicitly specifying a `permissions` block that restricts the default GITHUB_TOKEN privileges to only what the workflow needs. For a pure build/test workflow that only checks out code and does not modify the repository, `contents: read` is typically sufficient. This can be applied at the workflow level (top-level `permissions:`) to cover all jobs, or at the individual job level (under `jobs.<job>.permissions`). Since there is only one job (`build`) in the provided snippet, either location will work, but a top-level block makes it clear that all jobs in this workflow are restricted.

The best minimal fix without changing behavior is to add a root-level `permissions` block right after the `name: CI` line, with `contents: read`. None of the shown steps require any other scopes (they don’t write PR comments, releases, etc.), so narrowing to `contents: read` should not break functionality. Concretely, in `.github/workflows/ci.yml`, between line 1 (`name: CI`) and line 2 (`on:`), insert:

```yaml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed; this is purely a YAML configuration change within the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
